### PR TITLE
delay adapter initialization until first use

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -1,18 +1,5 @@
 package jpostcode
 
-var adapter Adapter
-
-func init() {
-	// set default adapter
-	var err error
-	adapter, err = newBadgerAdapter()
-	if err != nil {
-		panic(err)
-	}
-	// closing DB is not needed because badger adapter is using in-memory DB
-	// adapter.db.Close()
-}
-
 type Adapter interface {
 	SearchAddressesFromPostCode(postCode string) ([]*Address, error)
 }

--- a/badger_test.go
+++ b/badger_test.go
@@ -66,3 +66,12 @@ func Test_convertJSONToAddress(t *testing.T) {
 		})
 	}
 }
+
+func Benchmark_newBadgerAdapter(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, err := newBadgerAdapter()
+		if err != nil {
+			b.Error(err)
+		}
+	}
+}

--- a/jpostcode.go
+++ b/jpostcode.go
@@ -1,5 +1,14 @@
 package jpostcode
 
+import (
+	"sync"
+)
+
+var (
+	adapter     Adapter
+	adapterOnce sync.Once
+)
+
 func Find(postCode string) (*Address, error) {
 	addresses, err := Search(postCode)
 	if err != nil {
@@ -12,5 +21,15 @@ func Find(postCode string) (*Address, error) {
 }
 
 func Search(postCode string) ([]*Address, error) {
+	adapterOnce.Do(func() {
+		// set default adapter
+		var err error
+		adapter, err = newBadgerAdapter()
+		if err != nil {
+			panic(err)
+		}
+		// closing DB is not needed because badger adapter is using in-memory DB
+		// adapter.db.Close()
+	})
 	return adapter.SearchAddressesFromPostCode(postCode)
 }


### PR DESCRIPTION
Initialization of adapter takes more than 100 ms.

```
Benchmark_newBadgerAdapter-8   	       8	 134631792 ns/op	241382637 B/op	 1990421 allocs/op
```

This fix avoids delays on Go binary startup by doing its initialization on first call of Find/Search.